### PR TITLE
Remove folder after backup

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ function noop() {}
 function serve(hyper, opts, httpResponse) {
   if (!opts) opts = {}
   if (!opts.onCleanup) opts.onCleanup = noop
-  if (!opts.dir) opts.dir = process.cwd()
   if (!opts.backupName) opts.backupName = Date.now().toString()
+  if (!opts.dir) opts.dir = hyper.location
   if (Object.keys(opts).indexOf('cleanup') === -1) opts.cleanup = true
   var backupPath = path.join(opts.dir, 'backup-' + opts.backupName)
   hyper.liveBackup(opts.backupName, function(err) {

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ function noop() {}
 function serve(hyper, opts, httpResponse) {
   if (!opts) opts = {}
   if (!opts.onCleanup) opts.onCleanup = noop
-  if (!opts.backupName) opts.backupName = +new Date()
   if (!opts.dir) opts.dir = process.cwd()
+  if (!opts.backupName) opts.backupName = Date.now().toString()
   if (Object.keys(opts).indexOf('cleanup') === -1) opts.cleanup = true
   var backupPath = path.join(opts.dir, 'backup-' + opts.backupName)
   hyper.liveBackup(opts.backupName, function(err) {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "backup",
     "snapshot"
   ],
+  "scripts": {
+    "test": "tape test.js"
+  },
   "main": "index.js",
   "author": "max ogden",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "folder-backup": "~0.0.2"
     "folder-backup": "~0.0.2",
     "rimraf": "^2.5.2"
   },
@@ -24,5 +26,11 @@
   "bugs": {
     "url": "https://github.com/maxogden/hyperlevel-backup/issues"
   },
-  "homepage": "https://github.com/maxogden/hyperlevel-backup"
+  "homepage": "https://github.com/maxogden/hyperlevel-backup",
+  "devDependencies": {
+    "after": "^0.8.1",
+    "level-hyper": "^1.2.1",
+    "tape": "^4.5.1",
+    "tar": "^2.2.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "folder-backup": "~0.0.2"
+    "folder-backup": "~0.0.2",
+    "rimraf": "^2.5.2"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,99 @@
+var test = require('tape')
+var level = require('level-hyper')
+var os = require('os')
+var path = require('path')
+var rimraf = require('rimraf')
+var http = require('http')
+var backup = require('./index')
+var zlib = require('zlib')
+var tar = require('tar')
+var fs = require('fs')
+var after = require('after')
+
+test('should be able to do a backup and leave the backup', function (t) {
+  t.plan(1)
+  var dbPath = path.join(os.tmpdir(), 'hyperlevel-backup-' + Date.now())
+  var backupPath = path.join(os.tmpdir(), 'hyperlevel-backup-unpack-' + Date.now())
+  var db = level(dbPath, function (err) {
+    var server = http.createServer(function (req, res) {
+      backup(db.db, { cleanup: false }, res)
+    })
+    server.listen(0, function () {
+      http.get('http://localhost:' + server.address().port, function (res) {
+        fs.readdir(dbPath, function (err, files) {
+          if (err) throw err
+          var expected = files.filter(isDatabaseBackupFile).sort()
+          var results = []
+          res
+            .pipe(zlib.createGunzip())
+            .pipe(tar.Parse())
+            .on('entry', function (entry) {
+              if (entry.type === 'File') {
+                results.push(entry.path)
+              }
+            })
+            .on('end', function () {
+              t.deepEqual(expected, results.sort(), 'correct files present')
+              var next = after(4, t.end.bind(t))
+              rimraf(dbPath, next)
+              rimraf(backupPath, next)
+              db.close(next)
+              server.close(next)
+            })
+        })
+      })
+    })
+  })
+})
+
+test('should be able to do a backup and cleanup the backup', function (t) {
+  t.plan(2)
+
+  var dbPath = path.join(os.tmpdir(), 'hyperlevel-backup-' + Date.now())
+  var backupPath = path.join(os.tmpdir(), 'hyperlevel-backup-unpack-' + Date.now())
+  var db = level(dbPath, function (err) {
+    var server = http.createServer(function (req, res) {
+      backup(db.db, { cleanup: true, onCleanup: checkDir }, res)
+    })
+
+    function checkDir() {
+      fs.readdir(dbPath, function (err, files) {
+        if (err) throw err
+        t.equal(files.filter(isBackup).length, 0, 'backup folder empty')
+      })
+    }
+
+    server.listen(0, function () {
+      http.get('http://localhost:' + server.address().port, function (res) {
+        fs.readdir(dbPath, function (err, files) {
+          if (err) throw err
+          var expected = files.filter(isDatabaseBackupFile).sort()
+          var results = []
+          res
+            .pipe(zlib.createGunzip())
+            .pipe(tar.Parse())
+            .on('entry', function (entry) {
+              if (entry.type === 'File') {
+                results.push(entry.path)
+              }
+            })
+            .on('end', function () {
+              t.deepEqual(expected, results.sort(), 'correct files present')
+              var next = after(3, t.end.bind(t))
+              rimraf(dbPath, next)
+              rimraf(backupPath, next)
+              server.close(next)
+            })
+        })
+      })
+    })
+  })
+})
+
+function isDatabaseBackupFile(file) {
+  return !(isBackup(file) || file === 'LOCK')
+}
+
+function isBackup(file) {
+  return file.match(/^backup-/)
+}


### PR DESCRIPTION
The current version of `hyperlevel-backup` has some problems:
- the backup never gets removed because of a bug in `folder-backup`. This bug is fixed in [this pr](https://github.com/maxogden/folder-backup/pull/2) which stops the callback ever being called.
- `rimraf` is not in `package.json`
- The default backup name is an integer which `liveBackup` throws an error as the file name needs to be a string.
- The `dir` location needs to be figured out by the user, whereas we can default it to `hyper.location` instead of the current working dir for convenience.

I've fixed this as well as adding some `tape` tests.

To merge this you'll need to land the https://github.com/maxogden/folder-backup/pull/2 pull-request to make the tests pass.
